### PR TITLE
Cap uri-ssh_git version

### DIFF
--- a/pully-cli.gemspec
+++ b/pully-cli.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_runtime_dependency 'git'
-  gem.add_runtime_dependency 'uri-ssh_git'
+  gem.add_runtime_dependency 'uri-ssh_git', '>= 1.0', '< 2.0'
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Hi, I'll update `uri-ssh_git` api, so would you cap `uri-ssh_git`
`v1.x`?

https://github.com/packsaddle/ruby-uri-ssh_git/blob/c9d1c1c6ff1812cd3ecfef7ece30a1ea77cee677/changelog.md#200pre1-2015-12-03
